### PR TITLE
Remove useless utf8 import

### DIFF
--- a/lib/Class/Field.pm
+++ b/lib/Class/Field.pm
@@ -72,7 +72,6 @@ sub field {
     my $sub = eval $code;
     die $@ if $@;
     no strict 'refs';
-    use utf8;
     my $method = "${package}::$field";
     $method = Encode::decode_utf8($method);
     *{$method} = $sub;


### PR DESCRIPTION
According to [perldoc](https://perldoc.perl.org/utf8.html), this pragma is only called for when the source code itself might include non-ASCII bytes.