### PR TITLE
Add support for `-isa`

### DIFF
--- a/doc/Class/Field.swim
+++ b/doc/Class/Field.swim
@@ -4,12 +4,14 @@
 
   package Thing;
   use Class::Field qw'field const';
+  use Types::Standard qw(Int);
 
   field 'this';
   field 'list' => [];
   field 'map' => {};
   field 'that', -init => '$self->setup_that';
   field 'circular_ref' => -weaken;
+  field 'counter', -init => '0', -isa => Int;
   const 'answer' => 42;
 
 = Description
@@ -42,6 +44,11 @@ for speed.
   The first parameter passed to `field` is the name of the attribute being
   defined. Accessors can be given an optional default value. This value will
   be returned if no value for the field has been set in the object.
+
+  The `-isa` argument allows you to set a type constraint for the field's
+  value. It can be either a blessed object with a `check` method (like
+  L<Type::Tiny>, L<MooseX::Types>, etc) or a coderef that inspects `$_`
+  and returns a boolean. Default values are not checked.
 
 - `const`
 

--- a/test/field-types.t
+++ b/test/field-types.t
@@ -5,7 +5,7 @@ use Test::More;
 
 BEGIN {
     eval { require Types::Standard; }
-        ? plan(tests    => 1)
+        ? plan(tests    => 4)
         : plan(skip_all => 'test require Types::Standard')
 };
 

--- a/test/field-types.t
+++ b/test/field-types.t
@@ -1,0 +1,53 @@
+use strict;
+use lib (-e 't' ? 't' : 'test'), 'inc';
+
+use Test::More;
+
+BEGIN {
+    eval { require Types::Standard; }
+        ? plan(tests    => 1)
+        : plan(skip_all => 'test require Types::Standard')
+};
+
+package Foo;
+use base 'TestFieldBase';
+use Class::Field 'field';
+use Types::Standard qw( ArrayRef );
+
+field 'x', -isa => sub { not ref };
+field 'y' => [], -isa => ArrayRef;
+field 'z' => {}, -isa => sub { die "not hash" unless ref eq 'HASH' };
+field 'i', -init => '$self->hello';
+
+sub hello {
+    my $self = shift;
+    return 'Howdy';
+}
+
+package main;
+
+my $foo = Foo->new;
+
+$foo->y( [] );
+is_deeply($foo->y, []);
+
+{
+    local $@;
+    my $e;
+    eval { $foo->x([]); 1 } or $e = $@;
+    like($e, qr/failed isa check for x/);
+}
+
+{
+    local $@;
+    my $e;
+    eval { $foo->y(123); 1 } or $e = $@;
+    like($e, qr/did not pass type/);
+}
+
+{
+    local $@;
+    my $e;
+    eval { $foo->z(123); 1 } or $e = $@;
+    like($e, qr/not hash/);
+}


### PR DESCRIPTION
I don't know whether this might be something you want included or not, and if so whether it might be suitable for backporting to Spiffy, but it gives you a useful feature with not many extra lines of code.

**Usage:**

```perl
use Class::Field qw( field );
use Types::Standard qw( Int );

field 'count', -isa => Int;
```

or 

```perl
use Class::Field qw( field );

field 'count', -isa => sub { /\A-?[0-9]+\z/ };
```

or 

```perl
use Class::Field qw( field );

field 'count', -isa => sub { /\A-?[0-9]+\z/ or die "count should be an integer" };
```